### PR TITLE
Fix reddit account linking and display issues

### DIFF
--- a/app/(app)/social-accounts/page.tsx
+++ b/app/(app)/social-accounts/page.tsx
@@ -52,15 +52,18 @@ export default function SocialAccountsPage() {
   const [credStatus, setCredStatus] = useState<"unknown" | "ok" | "invalid">("unknown")
   const { toast } = useToast()
 
-  // Persist auth in session (ephemeral for demo)
+  // Persist auth in storage so popup can read it
   useEffect(() => {
     try {
-      const raw = sessionStorage.getItem("adtask_auth")
+      const raw = localStorage.getItem("adtask_auth") || sessionStorage.getItem("adtask_auth")
       if (raw) setAuth(JSON.parse(raw))
     } catch {}
   }, [])
   useEffect(() => {
-    if (auth) sessionStorage.setItem("adtask_auth", JSON.stringify(auth))
+    if (auth) {
+      sessionStorage.setItem("adtask_auth", JSON.stringify(auth))
+      localStorage.setItem("adtask_auth", JSON.stringify(auth))
+    }
   }, [auth])
 
   const services = useMemo(
@@ -321,7 +324,7 @@ function RedditOAuthButton({ auth, label = "Connect via Reddit OAuth" }: { auth:
         try {
           const u = new URL(url)
           // Force redirect_uri to our callback if backend returned a generic one
-          const desired = `${window.location.origin}/social-accounts/reddit-callback`
+          const desired = `${window.location.origin}/social-accounts/reddit-callback.html`
           u.searchParams.set("redirect_uri", desired)
           url = u.toString()
         } catch { /* leave as-is if not a valid URL */ }

--- a/app/(app)/social-accounts/reddit-callback/page.tsx
+++ b/app/(app)/social-accounts/reddit-callback/page.tsx
@@ -9,7 +9,7 @@ export default function RedditCallbackPage() {
   useEffect(() => {
     const code = params.get("code")
     const state = params.get("state")
-    const authRaw = sessionStorage.getItem("adtask_auth")
+    const authRaw = localStorage.getItem("adtask_auth") || sessionStorage.getItem("adtask_auth")
     if (!code || !state || !authRaw) {
       if (window.opener) {
         window.opener.postMessage({ type: "reddit_oauth_done", ok: false }, "*")
@@ -30,7 +30,7 @@ export default function RedditCallbackPage() {
             "content-type": "application/json",
             authorization,
           },
-          body: JSON.stringify({ code, state, redirect_uri: `${window.location.origin}/social-accounts/reddit-callback` }),
+          body: JSON.stringify({ code, state, redirect_uri: `${window.location.origin}/social-accounts/reddit-callback.html` }),
         })
         if (!resp.ok) throw new Error(await resp.text())
         if (window.opener) {

--- a/app/api/reddit/oauth/start/route.ts
+++ b/app/api/reddit/oauth/start/route.ts
@@ -7,7 +7,8 @@ export async function POST(request: NextRequest) {
   if (!auth) return NextResponse.json({ error: "Missing Authorization" }, { status: 401 })
 
   try {
-    const redirect = encodeURIComponent(`${request.nextUrl.origin}/social-accounts/reddit-callback`)
+    // Use static HTML callback to avoid Next.js chunk loading issues in popup
+    const redirect = encodeURIComponent(`${request.nextUrl.origin}/social-accounts/reddit-callback.html`)
     // Backend expects GET /api/reddit-oauth/auth-url (optionally with redirect_uri)
     const url = `${ADTASK_BASE_URL}/api/reddit-oauth/auth-url?redirect_uri=${redirect}`
     const resp = await fetch(url, {

--- a/public/social-accounts/reddit-callback.html
+++ b/public/social-accounts/reddit-callback.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reddit OAuth Callback</title>
+    <style>
+      html, body { height: 100%; margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+      .wrap { height: 100%; display: grid; place-items: center; background: #0b0b0c; color: #e5e7eb; }
+      .card { padding: 20px 24px; border-radius: 12px; background: #111113; box-shadow: 0 10px 30px rgba(0,0,0,.35); min-width: 320px; text-align: center; }
+      .muted { color: #9ca3af; font-size: 12px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <div id="status">Finalizing Reddit authorization…</div>
+        <div class="muted" id="hint">Please wait. You can close this window after completion.</div>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        const state = params.get('state');
+
+        function notify(opOk) {
+          try {
+            if (window.opener && !window.opener.closed) {
+              window.opener.postMessage({ type: 'reddit_oauth_done', ok: !!opOk }, '*');
+              window.close();
+              return;
+            }
+          } catch (_) {}
+          // Fallback: redirect back to the app
+          window.location.replace('/social-accounts' + (opOk ? '?oauth=ok' : '?oauth=failed'));
+        }
+
+        function setStatus(text) {
+          var el = document.getElementById('status');
+          if (el) el.textContent = text;
+        }
+
+        if (!code || !state) {
+          setStatus('Missing authorization code or state.');
+          return notify(false);
+        }
+
+        try {
+          // Prefer localStorage so the popup can access credentials set in the main window
+          var authRaw = localStorage.getItem('adtask_auth') || sessionStorage.getItem('adtask_auth');
+          if (!authRaw) throw new Error('Missing credentials in storage');
+          var parsed = {};
+          try { parsed = JSON.parse(authRaw); } catch (_) {}
+
+          var authorization = '';
+          if (parsed && parsed.mode === 'bearer' && parsed.token) {
+            authorization = 'Bearer ' + parsed.token;
+          } else if (parsed && parsed.username && parsed.password) {
+            authorization = 'Basic ' + btoa(parsed.username + ':' + parsed.password);
+          }
+          if (!authorization) throw new Error('Invalid or missing credentials');
+
+          setStatus('Linking Reddit account…');
+          fetch('/api/adtask/api/reddit-oauth/callback', {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+              'authorization': authorization
+            },
+            body: JSON.stringify({
+              code: code,
+              state: state,
+              redirect_uri: window.location.origin + '/social-accounts/reddit-callback.html'
+            })
+          })
+          .then(function (resp) { return resp.ok ? resp.text() : resp.text().then(function(t){ throw new Error(t || ('HTTP ' + resp.status)); }); })
+          .then(function () { notify(true); })
+          .catch(function (err) {
+            console.error('Reddit callback failed:', err);
+            setStatus('Authorization failed.');
+            notify(false);
+          });
+        } catch (e) {
+          console.error('Callback error:', e);
+          setStatus('Authorization failed.');
+          notify(false);
+        }
+      })();
+    </script>
+  </body>
+  </html>


### PR DESCRIPTION
Implement a static HTML callback for Reddit OAuth and persist credentials to localStorage to fix account linking issues.

The previous Next.js callback page in a popup was prone to chunk loading errors, preventing successful authorization. This change introduces a static HTML callback to avoid these issues and ensures the authentication token is available in `localStorage` for the popup to complete the linking process.

---
<a href="https://cursor.com/background-agent?bcId=bc-465b5849-e0d2-41ce-9755-20702c92dc73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-465b5849-e0d2-41ce-9755-20702c92dc73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

